### PR TITLE
Added a missing / to pr2-brand and changed postinst branding to defaults

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -46,11 +46,11 @@ try:
 except:
   print 'robot'
 """`
-        C1_NAME=`cat /etc/hostname`
-        C2_NAME=`cat /unionfs/overlay/etc/hostname`
+        C1_NAME="c1"
+        C2_NAME="c2"
         NUC_NAME="pr2-head"
-        BASESTATION_IP=`cat /tmp/pr2-network/BASESTATION_IP`
-        BASESTATION_HOSTNAME=`cat /tmp/pr2-network/BASESTATION_HOSTNAME`
+        BASESTATION_IP="10.68.255.1"
+        BASESTATION_HOSTNAME="basestation"
         echo Rebranding robot with: ${ROBOT_NAME} ${C1_NAME} ${C2_NAME} ${NUC_NAME} ${BASESTATION_IP} ${BASESTATION_HOSTNAME}
         pr2-brand ${ROBOT_NAME} ${C1_NAME} ${C2_NAME} ${NUC_NAME} ${BASESTATION_IP} ${BASESTATION_HOSTNAME}
     fi

--- a/root/usr/sbin/pr2-brand
+++ b/root/usr/sbin/pr2-brand
@@ -90,7 +90,7 @@ s/10\.68\.0\.91(\s+\S+){1,2}/10\.68\.0\.91 c1-esms ${MASTER_NAME}-esms/;
 s/10\.68\.0\.2(\s+\S+){2,4}/10\.68\.0\.2 ${SLAVE_NAME} c2 c2-lan0 ${SLAVE_NAME}-lan0/;
 s/10\.68\.0\.12(\s+\S+){1,2}/10\.68\.0\.12 c2-lan1 ${SLAVE_NAME}-lan1/;
 s/10\.68\.0\.92(\s+\S+){1,2}/10\.68\.0\.92 c2-esms ${SLAVE_NAME}-esms/;
-s/10\.68\.0\.10(\s+\S+){2,4}/10\.68\.0\.10 ${NUC_NAME} pr2-head;
+s/10\.68\.0\.10(\s+\S+){2,4}/10\.68\.0\.10 ${NUC_NAME} pr2-head/;
 s/10\.68\.255\.1\s+.*/10\.68\.255\.1 ${BASESTATION_HOSTNAME}/;
 s/^[^#]* basestation-novpn/${BASESTATION_IP} basestation-novpn/;
 " /etc/hosts > $TMPFILE


### PR DESCRIPTION
@TheDash 

Defaults are from the pr2-brand script where the default basestation IP is 10.68.255.1 and there is no default basestation hostname so I just went with "basestation"